### PR TITLE
Support persistent data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ ADD https://github.com/turtlecoin/checkpoints/raw/master/checkpoints.csv /tmp/ch
 VOLUME /var/lib/turtlecoind
 WORKDIR /var/lib/turtlecoind
 ENTRYPOINT ["/usr/local/bin/TurtleCoind"]
-CMD ["--no-console","--data-dir","/var/lib/turtlecoind","--rpc-bind-ip","0.0.0.0","--rpc-bind-port","11898","--p2p-bind-port","11897","--enable-cors=*","--enable_blockexplorer","--load-checkpoints","/tmp/checkpoints/checkpoints.csv"]
+CMD ["--no-console","--data-dir","/var/lib/turtlecoind","--rpc-bind-ip","0.0.0.0","--rpc-bind-port","11898","--p2p-bind-port","11897","--enable-cors=*","--enable_blockexplorer","--load-checkpoints","/tmp/checkpoints/checkpoints.csv","--log-file","/var/lib/turtlecoind/TurtleCoind.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ COPY --from=builder /opt/turtlecoin/build/src/simplewallet .
 COPY --from=builder /opt/turtlecoin/build/src/miner .
 RUN mkdir -p /var/lib/turtlecoind && mkdir /tmp/checkpoints
 ADD https://github.com/turtlecoin/checkpoints/raw/master/checkpoints.csv /tmp/checkpoints
-VOLUME /var/lib/turtlecoind
 WORKDIR /var/lib/turtlecoind
 ENTRYPOINT ["/usr/local/bin/TurtleCoind"]
 CMD ["--no-console","--data-dir","/var/lib/turtlecoind","--rpc-bind-ip","0.0.0.0","--rpc-bind-port","11898","--p2p-bind-port","11897","--enable-cors=*","--enable_blockexplorer","--load-checkpoints","/tmp/checkpoints/checkpoints.csv","--log-file","/var/lib/turtlecoind/TurtleCoind.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ COPY --from=builder /opt/turtlecoin/build/src/TurtleCoind .
 COPY --from=builder /opt/turtlecoin/build/src/walletd .
 COPY --from=builder /opt/turtlecoin/build/src/simplewallet .
 COPY --from=builder /opt/turtlecoin/build/src/miner .
-RUN mkdir -p /var/lib/turtlecoind && mkdir /tmp/checkpoints
+RUN mkdir -p /var/lib/turtlecoind && mkdir /tmp/checkpoints && mkdir /log
 ADD https://github.com/turtlecoin/checkpoints/raw/master/checkpoints.csv /tmp/checkpoints
 WORKDIR /var/lib/turtlecoind
 ENTRYPOINT ["/usr/local/bin/TurtleCoind"]
-CMD ["--no-console","--data-dir","/var/lib/turtlecoind","--rpc-bind-ip","0.0.0.0","--rpc-bind-port","11898","--p2p-bind-port","11897","--enable-cors=*","--enable_blockexplorer","--load-checkpoints","/tmp/checkpoints/checkpoints.csv","--log-file","/var/lib/turtlecoind/TurtleCoind.log"]
+CMD ["--no-console","--data-dir","/var/lib/turtlecoind","--rpc-bind-ip","0.0.0.0","--rpc-bind-port","11898","--p2p-bind-port","11897","--enable-cors=*","--enable_blockexplorer","--load-checkpoints","/tmp/checkpoints/checkpoints.csv","--log-file","/log/TurtleCoind.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ COPY --from=builder /opt/turtlecoin/build/src/TurtleCoind .
 COPY --from=builder /opt/turtlecoin/build/src/walletd .
 COPY --from=builder /opt/turtlecoin/build/src/simplewallet .
 COPY --from=builder /opt/turtlecoin/build/src/miner .
-RUN mkdir -p /var/lib/turtlecoind && mkdir /tmp/checkpoints && mkdir /log
+RUN mkdir -p /var/lib/turtlecoind && mkdir /tmp/checkpoints
 ADD https://github.com/turtlecoin/checkpoints/raw/master/checkpoints.csv /tmp/checkpoints
 WORKDIR /var/lib/turtlecoind
 ENTRYPOINT ["/usr/local/bin/TurtleCoind"]
-CMD ["--no-console","--data-dir","/var/lib/turtlecoind","--rpc-bind-ip","0.0.0.0","--rpc-bind-port","11898","--p2p-bind-port","11897","--enable-cors=*","--enable_blockexplorer","--load-checkpoints","/tmp/checkpoints/checkpoints.csv","--log-file","/log/TurtleCoind.log"]
+CMD ["--no-console","--data-dir","/var/lib/turtlecoind","--rpc-bind-ip","0.0.0.0","--rpc-bind-port","11898","--p2p-bind-port","11897","--enable-cors=*","--enable_blockexplorer","--load-checkpoints","/tmp/checkpoints/checkpoints.csv"]


### PR DESCRIPTION
* Enabled logging to filesystem (useful to debug historical faults)
* Moved checkpoints to /tmp/checkpoints, so that /var/lib/turtlecoind can be a persistent mount
* Changed stage2 image to debian9-slim to shave off a few MB