### PR TITLE
Rip walletd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,15 @@ RUN apt-get update && \
     make -j$(nproc)
 
 FROM debian:9
+
+# TurtleCoind now needs libreadline 
+RUN apt-get update && \
+    apt-get install -y \
+      libreadline-dev \
+     rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /usr/local/bin && mkdir -p /tmp/checkpoints 
+
 WORKDIR /usr/local/bin
 COPY --from=builder /opt/turtlecoin/build/src/TurtleCoind .
 COPY --from=builder /opt/turtlecoin/build/src/walletd .

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM debian:9
 RUN apt-get update && \
     apt-get install -y \
       libreadline-dev \
-     rm -rf /var/lib/apt/lists/*
+     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/local/bin && mkdir -p /tmp/checkpoints 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
     apt-get install -y \
       build-essential \
       gdb \
+      readline-dev \
       python-dev \
       gcc \
       g++\

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir -p /usr/local/bin && mkdir -p /tmp/checkpoints
 WORKDIR /usr/local/bin
 COPY --from=builder /opt/turtlecoin/build/src/TurtleCoind .
 COPY --from=builder /opt/turtlecoin/build/src/walletd .
-COPY --from=builder /opt/turtlecoin/build/src/simplewallet .
+COPY --from=builder /opt/turtlecoin/build/src/zedwallet .
 COPY --from=builder /opt/turtlecoin/build/src/miner .
 RUN mkdir -p /var/lib/turtlecoind
 WORKDIR /var/lib/turtlecoind

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p /usr/local/bin && mkdir -p /tmp/checkpoints
 
 WORKDIR /usr/local/bin
 COPY --from=builder /opt/turtlecoin/build/src/TurtleCoind .
-COPY --from=builder /opt/turtlecoin/build/src/walletd .
+COPY --from=builder /opt/turtlecoin/build/src/service .
 COPY --from=builder /opt/turtlecoin/build/src/zedwallet .
 COPY --from=builder /opt/turtlecoin/build/src/miner .
 RUN mkdir -p /var/lib/turtlecoind

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get install -y \
       build-essential \
       gdb \
-      readline-dev \
+      libreadline-dev \
       python-dev \
       gcc \
       g++\

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     make -j$(nproc)
 
 FROM debian:9
-RUN mkdir -p /usr/local/bin
+RUN mkdir -p /usr/local/bin && mkdir -p /tmp/checkpoints 
 WORKDIR /usr/local/bin
 COPY --from=builder /opt/turtlecoin/build/src/TurtleCoind .
 COPY --from=builder /opt/turtlecoin/build/src/walletd .
@@ -35,6 +35,6 @@ COPY --from=builder /opt/turtlecoin/build/src/simplewallet .
 COPY --from=builder /opt/turtlecoin/build/src/miner .
 RUN mkdir -p /var/lib/turtlecoind
 WORKDIR /var/lib/turtlecoind
-ADD https://github.com/turtlecoin/checkpoints/raw/master/checkpoints.csv /var/lib/turtlecoind
+ADD https://github.com/turtlecoin/checkpoints/raw/master/checkpoints.csv /tmp/checkpoints/
 ENTRYPOINT ["/usr/local/bin/TurtleCoind"]
-CMD ["--no-console","--data-dir","/var/lib/turtlecoind","--rpc-bind-ip","0.0.0.0","--rpc-bind-port","11898","--p2p-bind-port","11897","--enable-cors=*","--enable_blockexplorer","--load-checkpoints","/var/lib/turtlecoind/checkpoints.csv"]
+CMD ["--no-console","--data-dir","/var/lib/turtlecoind","--rpc-bind-ip","0.0.0.0","--rpc-bind-port","11898","--p2p-bind-port","11897","--enable-cors=*","--enable_blockexplorer","--load-checkpoints","/tmp/checkpoints/checkpoints.csv"]


### PR DESCRIPTION
Following from the readline PR, this PR adjusts for recent changes in the the upstream devel branch, renaming walletd to service